### PR TITLE
Fix: sequence expects str instead of int

### DIFF
--- a/rel/buff.py
+++ b/rel/buff.py
@@ -25,7 +25,7 @@ class BuffWrite(object):
 	def write(self, sock):
 		dlen = len(self.data)
 		if self.position >= dlen:
-			self.log("aborting! position", self.position, ">= len(data)", dlen, "(how?)")
+			self.log("aborting! position %s >= len(data) dlen: %s (how?)"%(self.position, dlen))
 			self.position = dlen
 		else:
 			try:


### PR DESCRIPTION
File "/home/ubuntu/.local/lib/python3.10/site-packages/rel/rel.py", line 228, in dispatch
    registrar.dispatch()
  File "/home/ubuntu/.local/lib/python3.10/site-packages/rel/registrar.py", line 134, in dispatch
    if not self.loop():
  File "/home/ubuntu/.local/lib/python3.10/site-packages/rel/registrar.py", line 146, in loop
    e = self.check_events()
  File "/home/ubuntu/.local/lib/python3.10/site-packages/rel/registrar.py", line 324, in check_events
    self.callback('write', fd)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/rel/registrar.py", line 194, in callback
    self.events[etype][fd].callback()
  File "/home/ubuntu/.local/lib/python3.10/site-packages/rel/listener.py", line 131, in callback
    if not self.cb(*self.args) and not self.persist and self.active:
  File "/home/ubuntu/.local/lib/python3.10/site-packages/rel/buff.py", line 73, in write
    bw.write(self.sock)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/rel/buff.py", line 28, in write
    self.log("aborting! position", self.position, ">= len(data)", dlen, "(how?)")
  File "/home/ubuntu/.local/lib/python3.10/site-packages/rel/buff.py", line 20, in log
    log("BuffWrite: %s"%(" ".join(msg),))
TypeError: sequence item 1: expected str instance, int found

Ran into this error while using rel with the websocket-client package. I have multiple WebSocketApp instances running using run_forever(), and dispatched with rel.  When a single websocket connection disconnects, this error occurs, stopping the entire process instead of allowing WebSocketApp to reconnect. I tried to be consistent with how you format strings in the rest of the file.