### PR TITLE
Fix race condition between timer add and delete

### DIFF
--- a/rel/registrar.py
+++ b/rel/registrar.py
@@ -84,9 +84,8 @@ def kbint(signals):
 class Registrar(Basic):
     def __init__(self):
         self.events = {'read':{},'write':{},'error':{}}
-        self.timers = []
-        self.addlist = []
-        self.rmlist = []
+        self.timers = set()
+        self.ordered_timers = None
         self.signals = {}
         self.tick = 0
         self.run_dispatch = False
@@ -167,26 +166,23 @@ class Registrar(Basic):
         return Timer(self,delay,cb,*args)
 
     def add_timer(self, timer):
-         self.addlist.append(timer)
+         self.timers.add(timer)
+         # Force a re-sort of the list
+         self.ordered_timers = None
 
     def remove_timer(self, timer):
-        self.rmlist.append(timer)
+         self.timers.discard(timer)
+         # Force a re-sort of the list
+         self.ordered_timers = None
 
     def check_timers(self):
-        changes = len(self.addlist) or len(self.rmlist)
-        for timer in self.addlist:
-            if timer not in self.timers:
-                self.timers.append(timer)
-        self.addlist = []
-        for timer in self.rmlist:
-            if timer in self.timers:
-                self.timers.remove(timer)
-        self.rmlist = []
-        changes and self.timers.sort(key=operator.attrgetter("expiration"))
+        if self.ordered_timers is None:
+            # The timers list has changed, create and sort it
+            self.ordered_timers = sorted(self.timers, key=operator.attrgetter("expiration"))
         t = time.monotonic()
-        for timer in self.timers:
+        for timer in self.ordered_timers:
             if not timer.check(t):
-                self.rmlist.append(timer)
+                self.remove_timer(timer)
         return bool(self.timers)
 
     def callback(self, etype, fd):

--- a/rel/test.py
+++ b/rel/test.py
@@ -87,7 +87,24 @@ class EventTest(unittest.TestCase):
         event.timeout(5, __timeout2_cb, time.monotonic(), 5)
         event.dispatch()
         self.assertTrue(self.call_back_ran, 'call back did not run')
-   
+
+    def test_timers(self):
+        """
+        Check that timers operations (add/delete) are performed in order.
+        """
+        timer_delay = 2
+        def _timer_cb():
+            self.call_back_ran = True
+            delay = int(time.monotonic() - loop_start)
+            assert delay == timer_delay, 'timers failed'
+
+        timer = event.timeout(timer_delay * 2, _timer_cb)
+        timer.delete()
+        timer.add(timer_delay)
+        loop_start = time.monotonic()
+        event.dispatch()
+        self.assertTrue(self.call_back_ran, 'call back did not run')
+
     def test_signal(self):
         if not hasattr(signal, 'SIGUSR1'):
             self.skip('signal.SIGUSR1 missing (probably Windows)')


### PR DESCRIPTION
If a timer is deleted and then added back before `Registrar.check_timers()` is called, it will not be added back to the list of timers because timers that a pending for deletion are always process after timers that are pending for addition. This PR fixes that by adding and removing timers as soon as the operation is requested.

It also uses a set to store the list of timers to make add/delete a quick operation. A set was already used originally, I guess it has been replaced with a list afterwards to make sure the timers list was in the correct order. This PR does not break that.

Ideally, the timers iteration should stop as soon as a non-expired timer is found, but the return valued from `Timer.check()` does not distinguish between a non-expired timer and a disabled timer.
