### PR TITLE
Fix BuffWriter reuse

### DIFF
--- a/rel/__init__.py
+++ b/rel/__init__.py
@@ -1,3 +1,3 @@
 from .version import __version__
 from .rel import override, supported_methods, initialize, set_verbose, set_sleep, set_turbo, safe_read, read, write, timeout, signal, error, event, dispatch, pause, resume, loop, report, is_running, abort, abort_branch, thread, tick, init, start, stop, EV_PERSIST, EV_READ, EV_SIGNAL, EV_TIMEOUT, EV_WRITE
-from .buff import buffwrite
+from .buff import buffwrite, release_buff

--- a/rel/buff.py
+++ b/rel/buff.py
@@ -89,8 +89,8 @@ class BuffWriter(object):
 	def ingest(self, data):
 		self.log("ingesting %s bytes"%(len(data),))
 		self.writes.append(BuffWrite(data, self.sender))
-		for etype in self.listeners:
-			self.listeners[etype].pending() or self.listeners[etype].add()
+		for event in self.listeners.values():
+			event.pending() or event.add()
 
 	def release(self):
 		self.log("release")

--- a/rel/buff.py
+++ b/rel/buff.py
@@ -92,9 +92,25 @@ class BuffWriter(object):
 		for etype in self.listeners:
 			self.listeners[etype].pending() or self.listeners[etype].add()
 
+	def release(self):
+		self.log("release")
+		self.writes = []
+		self.errors = []
+		for event in self.listeners.values():
+			event.delete()
+		self.listeners = {}
+
 def buffwrite(sock, data, sender, onerror):
 	writer = writings.get(sock)
 	if writer is not None:
 		writer.ingest(data)
 	else:
 		writings[sock] = BuffWriter(sock, data, sender, onerror)
+
+def release_buff(sock):
+	'''
+	Release the resources from the BuffWriter associated with the given socket.
+	'''
+	writer = writings.pop(sock, None)
+	if writer is not None:
+		writer.release()

--- a/rel/buff.py
+++ b/rel/buff.py
@@ -93,10 +93,8 @@ class BuffWriter(object):
 			self.listeners[etype].pending() or self.listeners[etype].add()
 
 def buffwrite(sock, data, sender, onerror):
-	fn = sock.fileno()
-	if fn in writings:
-		writings[fn].sock = sock
-		writings[fn].ingest(data)
+	writer = writings.get(sock)
+	if writer is not None:
+		writer.ingest(data)
 	else:
-		writings[fn] = BuffWriter(sock, data, sender, onerror)
-	
+		writings[sock] = BuffWriter(sock, data, sender, onerror)


### PR DESCRIPTION
Using the file number as the key for `writings` was a bad idea, because file numbers are re-used once the the file/socket is closed (e.g., in case of re-connection), so a new socket could be associated with a file number already used in `writings`, and thus, end up using an old `BuffWriter`, possibly with old data buffered or errors that prevent any write operations.
That was also a problem when there are multiple senders (the file number associated with a sender could become associated with another, but the `BuffWriter` still references the old sender).

Using `id(sock)` as the key could produce a similar situation, because the returned value is only guaranteed to be unique until the socket object is released.

Using `sock` as the key is similar as using `id(sock)`, except that the dict now holds a reference to the socket object, so the result of `id(sock)` is guaranteed to be unique as long as the socket object is a key in `writings`.

This PR also adds a method to remove `BuffWriter` resources when not needed anymore (e.g., when the socket is closed). I have a PR ready for websocket to use it.